### PR TITLE
chore: promise callback bug resolved

### DIFF
--- a/android/src/main/java/com/otplessreactnative/OtplessReactNativeModule.kt
+++ b/android/src/main/java/com/otplessreactnative/OtplessReactNativeModule.kt
@@ -121,7 +121,9 @@ class OtplessReactNativeModule(private val reactContext: ReactApplicationContext
     }
     otplessView!!.showOtplessFab(false)
     reactContext.currentActivity!!.runOnUiThread {
-      otplessView!!.startOtpless(jsonObject, this::sendEventCallback)
+      otplessView!!.startOtpless(jsonObject) {
+        sendSingleCallback(callback, it)
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otpless-react-native",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "react native plugin for otpless android and ios",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
When doing authentication with extra params, result callback was given to event instead of provided promise.